### PR TITLE
Parse more expressions, including CallExpressions

### DIFF
--- a/src/ast-to-expression.js
+++ b/src/ast-to-expression.js
@@ -1,11 +1,30 @@
 function astToExpression(input) {
   if (input.value) return input.value;
-  if (input.type === 'BinaryExpression') {
-    const left = astToExpression(input.left);
-    const right = astToExpression(input.right);
+  if (input.name) return input.name;
 
-    return [input.operator, left, right];
+  let expressionOperator;
+  let expressionArguments = [];
+
+  if (input.operator) {
+    expressionOperator = input.operator;
   }
+
+  if (input.type === 'BinaryExpression') {
+    expressionArguments.push(
+      astToExpression(input.left),
+      astToExpression(input.right)
+    );
+  }
+
+  if (input.type === 'CallExpression') {
+    expressionOperator = input.callee.name;
+
+    input.arguments.forEach(i => {
+      expressionArguments.push(astToExpression(i));
+    });
+  }
+
+  return [expressionOperator].concat(expressionArguments);
 }
 
 export default astToExpression;

--- a/test/ast-to-expression.test.js
+++ b/test/ast-to-expression.test.js
@@ -2,6 +2,11 @@ import stringToAst from '../src/string-to-ast';
 import astToExpression from '../src/ast-to-expression';
 
 describe('astToExpression', () => {
+  test('quack', () => {
+    const actual = astToExpression(stringToAst('quack'));
+    expect(actual).toBe('quack');
+  });
+
   test('3', () => {
     const actual = astToExpression(stringToAst('3'));
     expect(actual).toBe(3);
@@ -20,5 +25,35 @@ describe('astToExpression', () => {
   test('((3 + 4) * 2) / 7', () => {
     const actual = astToExpression(stringToAst('((3 + 4) * 2) / 7'));
     expect(actual).toEqual(['/', ['*', ['+', 3, 4], 2], 7]);
+  });
+
+  test('log2(3)', () => {
+    const actual = astToExpression(stringToAst('log(3)'));
+    expect(actual).toEqual(['log', 3]);
+  });
+
+  test('log2((3 + 4) / 7)', () => {
+    const actual = astToExpression(stringToAst('log((3 + 4) / 7)'));
+    expect(actual).toEqual(['log', ['/', ['+', 3, 4], 7]]);
+  });
+
+  test('min(2, 4, 6)', () => {
+    const actual = astToExpression(stringToAst('min(2, 4, 6)'));
+    expect(actual).toEqual(['min', 2, 4, 6]);
+  });
+
+  test('max(2, 4, 6)', () => {
+    const actual = astToExpression(stringToAst('max(2, 4, 6)'));
+    expect(actual).toEqual(['max', 2, 4, 6]);
+  });
+
+  test('max(2, 4, ((3 + 4) / 7))', () => {
+    const actual = astToExpression(stringToAst('max(2, 4, ((3 + 4) / 7))'));
+    expect(actual).toEqual(['max', 2, 4, ['/', ['+', 3, 4], 7]]);
+  });
+
+  test('max(3, log2(6))', () => {
+    const actual = astToExpression(stringToAst('max(3, log2(6))'));
+    expect(actual).toEqual(['max', 3, ['log2', 6]]);
   });
 });


### PR DESCRIPTION
As the additional tests show, this PR adds the ability to write the following strings to expressions:
* Binary expressions (`!5`)
* Call expressions with multiple arguments (if the operator is `min` or `max`)
* Call expressions with one argument (should cover logarithmic and trigonometric math expressions)
* Nesting within all of the above expressions

@davidtheclark I would love if you could give this a code review for tightness!
