### PR TITLE
Reject unquoted literal strings passed in as formulas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- **[BREAKING]** Reject unquoted literal strings as passed in as formulas to `formulaToExpression`.
+
 ## 0.3.2
 
 - Fix handling of symbolic decision operators, like `<=` and `!`.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This library translates these handwritten formulas into valid spec-compliant Map
   That is, the formula should contain `3 + 4` instead of `+(3, 4)`.
 - Symbolic decision operators also work with operands on both sides, instead of like function invocations.
   So `get("foo") != 4` instead of `!=(get("foo"), 4)`.
+- Strings must always be wrapped in quotation marks, e.g. `concat("egg", "s")` not `concat(egg, s)`.
 - `&` operator concatenates strings, as in spreadsheet programs.
 
 ```js

--- a/src/formula-to-expression.js
+++ b/src/formula-to-expression.js
@@ -13,11 +13,15 @@ function handleLiteralArgument(arg) {
         return handleLiteralArgument(item);
       });
     default:
-      throw new Error('Invalid syntax');
+      throw handleSyntaxErrors(new Error('Invalid syntax'));
   }
 }
 
 function astToExpression(input) {
+  if (input.type === 'Identifier') {
+    throw handleSyntaxErrors(new Error('Unexpected identifier'));
+  }
+
   if (input.value !== undefined) return input.value;
   if (input.name !== undefined) return input.name;
 

--- a/src/handle-syntax-errors.js
+++ b/src/handle-syntax-errors.js
@@ -1,8 +1,8 @@
-function handleSyntaxErrors(error, input) {
+function handleSyntaxErrors(error, input = '') {
   const newError = new Error('Syntax error');
   newError.type = 'SyntaxError';
   newError.index = error.index;
-  newError.description = error.description;
+  newError.description = error.description || error.message;
 
   if (/expression/.test(newError.description)) {
     newError.description = newError.description.replace('expression', 'value');

--- a/test/formula-to-expression.test.js
+++ b/test/formula-to-expression.test.js
@@ -16,7 +16,7 @@ describe('literals', () => {
     expect(actual).toBe(77.323);
   });
 
-  test('sing', () => {
+  test('"sing"', () => {
     const actual = formulaToExpression('"sing"');
     expect(actual).toBe('sing');
   });
@@ -56,6 +56,11 @@ describe('formulas', () => {
   test('((3 + 4) * 2) / 7', () => {
     const actual = formulaToExpression('((3 + 4) * 2) / 7');
     expect(actual).toEqual(['/', ['*', ['+', 3, 4], 2], 7]);
+  });
+
+  test('sing()', () => {
+    const actual = formulaToExpression('sing()');
+    expect(actual).toEqual(['sing']);
   });
 
   test('log2(3)', () => {
@@ -252,6 +257,38 @@ describe('syntax errors', () => {
       expect(error.type).toBe('SyntaxError');
       expect(error.index).toBe(2);
       expect(error.description).toBe('Unexpected input');
+    }
+  });
+
+  test('sing', () => {
+    const actual = () => {
+      formulaToExpression('sing');
+    };
+    expect(actual).toThrow('Syntax error');
+
+    expect.hasAssertions();
+    try {
+      formulaToExpression('sing');
+    } catch (error) {
+      expect(error.type).toBe('SyntaxError');
+      expect(error.index).toBe(undefined);
+      expect(error.description).toBe('Unexpected identifier');
+    }
+  });
+
+  test('concat(foo, bar)', () => {
+    const actual = () => {
+      formulaToExpression('concat(foo, bar)');
+    };
+    expect(actual).toThrow('Syntax error');
+
+    expect.hasAssertions();
+    try {
+      formulaToExpression('concat(foo, bar)');
+    } catch (error) {
+      expect(error.type).toBe('SyntaxError');
+      expect(error.index).toBe(undefined);
+      expect(error.description).toBe('Unexpected identifier');
     }
   });
 });


### PR DESCRIPTION
Before, you could (confusingly) provide unquoted strings. `foo` was a valid formula. So was `concat(foo, bar)`. With this change, strings consistently require quotation marks to be interpreted correctly. So `"foo"` could be a formula, and so could `concat("foo", "bar")`.

@dasulit for review.